### PR TITLE
Use PathBase to support Virtual Directory

### DIFF
--- a/core/Piranha.AspNetCore/IntegratedMiddleware.cs
+++ b/core/Piranha.AspNetCore/IntegratedMiddleware.cs
@@ -61,6 +61,7 @@ namespace Piranha.AspNetCore
                 service.Request.Url = service.Url = context.Request.Path.Value;
                 #pragma warning enable
                 service.Request.Host = context.Request.Host.Host;
+                service.Request.PathBase = context.Request.PathBase;
                 service.Request.Port = context.Request.Host.Port;
                 service.Request.Scheme = context.Request.Scheme;
 

--- a/core/Piranha.AspNetCore/Services/IRequestHelper.cs
+++ b/core/Piranha.AspNetCore/Services/IRequestHelper.cs
@@ -22,6 +22,11 @@ namespace Piranha.AspNetCore.Services
         string Host { get; set; }
 
         /// <summary>
+        /// Gets/sets the current PathBase, which represents an URI segment for a IIS or Azure App Service Virtual Directory.
+        /// </summary>
+        string PathBase { get; set; }
+
+        /// <summary>
         /// Gets/sets the current port.
         /// </summary>
         int? Port { get; set; }

--- a/core/Piranha.AspNetCore/Services/RequestHelper.cs
+++ b/core/Piranha.AspNetCore/Services/RequestHelper.cs
@@ -22,6 +22,11 @@ namespace Piranha.AspNetCore.Services
         public string Host { get; set; }
 
         /// <summary>
+        /// Gets/sets the current PathBase, which represents an URI segment for a IIS or Azure App Service Virtual Directory.
+        /// </summary>
+        public string PathBase { get; set; }
+
+        /// <summary>
         /// Gets/sets the current port.
         /// </summary>
         public int? Port { get; set; }

--- a/core/Piranha.AspNetCore/UrlGenerationExtensions.cs
+++ b/core/Piranha.AspNetCore/UrlGenerationExtensions.cs
@@ -295,18 +295,25 @@ public static class UrlGenerationExtensions
             slug = slug.Replace("~/", "/");
         }
 
-        // Fix slug that doesn't start with /
-        if (!slug.StartsWith("/"))
+        // Fix slug so it doesn't start with /
+        if (slug.StartsWith("/"))
         {
-            slug = $"/{ slug }";
+            slug = slug.Substring(1, slug.Length - 1);
         }
 
+        StringBuilder baseUrl = new StringBuilder();
+
+        // Append PathBase for IIS or Azure App Service Virtual Directory
+        if (!string.IsNullOrEmpty(app.Request.PathBase)) baseUrl.Append(app.Request.PathBase);
+        
+        baseUrl.Append(@"/");
+
         // Append site prefix, if available
-        if (!string.IsNullOrEmpty(app.Site.SitePrefix))
-        {
-            slug = $"/{ app.Site.SitePrefix }{ slug }";
-        }
-        return slug;
+        if (!string.IsNullOrEmpty(app.Site.SitePrefix)) baseUrl.Append(app.Site.SitePrefix);
+
+        if (!baseUrl.ToString().EndsWith(@"/")) baseUrl.Append(@"/");
+        
+        return $"{baseUrl}{slug}";
     }
 
     /// <summary>
@@ -338,6 +345,7 @@ public static class UrlGenerationExtensions
             sb.Append(":");
             sb.Append(app.Request.Port.ToString());
         }
+        if (!string.IsNullOrEmpty(app.Request.PathBase)) sb.Append(app.Request.PathBase);
         return sb.ToString();
     }
 }

--- a/examples/MvcWeb/Views/Shared/Partial/_Menu.cshtml
+++ b/examples/MvcWeb/Views/Shared/Partial/_Menu.cshtml
@@ -14,7 +14,7 @@
                 if (!item.IsHidden)
                 {
                     <li class="nav-item @(item.Id == WebApp.PageId || item.HasChild(WebApp.PageId) ? "active" : "")">
-                        <a class="nav-link" href="@item.Permalink">@item.MenuTitle</a>
+                        <a class="nav-link" href="@WebApp.Url(item)">@item.MenuTitle</a>
                     </li>
                 }
             }


### PR DESCRIPTION
Changes to various components to make use of PathBase for IIS Virtual Directories.

The previous functionality has no unit tests and the changes haven't been thoroughly tested. I.e. no multi-site Piranha application has been tested with the changed framework. 

The site template also needs a change to make use of the new feature of the Piranha.AspNetCore package. Menu item links must use `WebApp.Url(sitemapItem)` to generate correct URLs:
```
<div class="navbar-collapse collapse" id="mobileNavbar">
        <ul class="justify-content-center navbar-nav mr-auto">

            @foreach (var item in WebApp.Site.Sitemap)
            {
                if (!item.IsHidden)
                {
                    <li class="nav-item @(item.Id == WebApp.PageId || item.HasChild(WebApp.PageId) ? "active" : "")">
                        <a class="nav-link" href="@WebApp.Url(item)">@item.MenuTitle</a>
                    </li>
                }
            }
        </ul>
    </div>
```